### PR TITLE
Redirect checkpoint URLs without a trailing slash

### DIFF
--- a/CHANGES/6812.bugfix
+++ b/CHANGES/6812.bugfix
@@ -1,0 +1,1 @@
+Redirect checkpoint URLs without a trailing slash to add the slash.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -705,8 +705,11 @@ class Handler:
         rel_path = rel_path[len(distro.base_path) :]
         rel_path = rel_path.lstrip("/")
 
-        if rel_path == "" and not path.endswith("/"):
-            # The root of a distribution base_path was requested without a slash
+        # Check if we need to redirect to add a trailing slash for distro root
+        if not path.endswith("/") and (
+            rel_path == ""  # Distro root
+            or (distro.checkpoint and "/" not in rel_path)  # Timestamped checkpoint root
+        ):
             raise HTTPMovedPermanently(f"{request.path}/")
 
         original_rel_path = rel_path

--- a/pulpcore/tests/functional/api/using_plugin/test_checkpoint.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_checkpoint.py
@@ -87,17 +87,39 @@ class TestCheckpointDistribution:
         assert Handler._format_checkpoint_timestamp(pubs[3].pulp_created) in checkpoints_ts
 
     @pytest.mark.parallel
-    def test_no_trailing_slash_is_redirected(self, setup, http_get, distribution_base_url):
+    def test_distro_root_no_trailing_slash_is_redirected(
+        self,
+        setup,
+        http_get,
+        distribution_base_url,
+    ):
         """Test checkpoint listing when path doesn't end with a slash."""
 
         pubs, distribution = setup
 
+        # Test a checkpoint distro listing path
         response = http_get(distribution_base_url(distribution.base_url[:-1])).decode("utf-8")
         checkpoints_ts = set(re.findall(r"\d{8}T\d{6}Z", response))
 
         assert len(checkpoints_ts) == 2
         assert Handler._format_checkpoint_timestamp(pubs[1].pulp_created) in checkpoints_ts
         assert Handler._format_checkpoint_timestamp(pubs[3].pulp_created) in checkpoints_ts
+
+    @pytest.mark.parallel
+    def test_timestamped_checkpoint_no_trailing_slash_is_redirected(
+        self,
+        setup,
+        http_get,
+        checkpoint_url,
+    ):
+        """Test a timestamped checkpoint when path doesn't end with a slash."""
+
+        pubs, distribution = setup
+
+        pub_1_url = checkpoint_url(distribution, pubs[1].pulp_created)
+        response = http_get(pub_1_url[:-1]).decode("utf-8")
+
+        assert f"<h1>Index of {urlparse(pub_1_url).path}</h1>" in response
 
     @pytest.mark.parallel
     def test_exact_timestamp_is_served(self, setup, http_get, checkpoint_url):


### PR DESCRIPTION
Redirect checkpoint URLs without a trailing slash to add a slash

closes #6812