### PR TITLE
Fix repository validation for shared artifacts

### DIFF
--- a/CHANGES/6868.bugfix
+++ b/CHANGES/6868.bugfix
@@ -1,0 +1,1 @@
+Fixed repository version validation to allow legitimate shared artifacts between content units.

--- a/pulpcore/plugin/repo_version_utils.py
+++ b/pulpcore/plugin/repo_version_utils.py
@@ -116,9 +116,15 @@ def validate_version_paths(version):
     Raises:
         ValueError: If two artifact relative paths overlap
     """
-    paths = ContentArtifact.objects.filter(content__pk__in=version.content).values_list(
-        "relative_path", flat=True
+    # Get unique (path, artifact) pairs to allow artifacts shared across content
+    content_artifacts = (
+        ContentArtifact.objects.filter(content__pk__in=version.content)
+        .values_list("relative_path", "artifact")
+        .distinct()
     )
+
+    paths = [path for path, artifact_id in content_artifacts]
+
     try:
         validate_file_paths(paths)
     except ValueError as e:


### PR DESCRIPTION
Repository version validation now allows multiple content units to reference the same artifact at the same relative path. Previously, the validate_version_paths function treated any duplicate relative path as an error, even when multiple content units legitimately shared the same artifact.

closes #6868